### PR TITLE
refactored controller to not repeat the same api call twice

### DIFF
--- a/app/Controllers/Pensador.php
+++ b/app/Controllers/Pensador.php
@@ -13,15 +13,14 @@ class Pensador extends BaseController
 
     public function imagem_recente()
     {
-        $pensadorModel = new PensadorModel;
-        $urlImg = $pensadorModel->getLastImage();
+        $urlImg = PensadorModel::getLastImage();
 
         if ($urlImg ===  false){
             header($_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error', true, 500);
             exit();
         }
 
-        header('location:' . $pensadorModel->getLastImage());
+        header('location:' . $urlImg);
         exit();
     }
 }

--- a/app/Models/PensadorModel.php
+++ b/app/Models/PensadorModel.php
@@ -6,7 +6,7 @@ use voku\helper\HtmlDomParser;
 
 class PensadorModel
 {
-    public function getLastImage()
+    public static function getLastImage()
     {
         $urlRecent = 'https://www.pensador.com/recentes/';
         try {


### PR DESCRIPTION
Fixed following issues:
* getLastImage was called twice
* Updated getLastImage to be a static method instead since there was no use in declaring an instance of PensadorModel